### PR TITLE
Make dependency for latexflat a bit more strict

### DIFF
--- a/src/reprepbuild/__main__.py
+++ b/src/reprepbuild/__main__.py
@@ -133,7 +133,7 @@ def latex_pattern(path):
         yield {
             "outputs": fixpath(f"{prefix}-flat.tex"),
             "rule": "latexflat",
-            "implicit": fixpath(f"{prefix}.tex.dd"),
+            "order_only": fixpath(f"{prefix}.pdf"),
             "inputs": fixpath(f"{prefix}.tex"),
         }
         yield {


### PR DESCRIPTION
This is to enforce having all inputs for the main tex file ready when flattening the source.